### PR TITLE
Fix right-to-left text selection

### DIFF
--- a/Mokuro2Pdf.rb
+++ b/Mokuro2Pdf.rb
@@ -241,13 +241,13 @@ for folder in folders do
                             next if (levelLine[textLevels[level]].nil? || levelLine[textLevels[level]] == 0 || levelLine[textLevels[level]].to_s == '')
                             boxWidth = levelWidth[level][1] - levelWidth[level][2]
                             boxLength = levelLine[textLevels[level]].length
-                            boxLeft = levelWidth[level][2]
                             boxFSize = levelLine[textLevels[level]].reduce(99999) {|smallest, line| (line[1] < smallest) && (line[1] > (line[2] * 0.3)) ? line[1] : smallest}
                             lineSpace = 1.1
                             if boxLength > 1
                                 lineSpace = ((boxWidth - (boxLength * boxFSize)) / (boxLength - 1)) + boxFSize
                             end
-                            for line in levelLine[textLevels[level]].reverse do
+                            boxLeft = levelWidth[level][2] + lineSpace * (boxLength - 1)
+                            for line in levelLine[textLevels[level]] do
                                 next if line[1] <= (line[2] * 0.5)
                                 fontSize = line[1]
                                 line = line[0].strip.gsub(/(．．．)/, "…").gsub(/(．．)/, "‥").gsub(/(．)/, "").gsub(/\s/, "").gsub(/[。\.．、，,…‥!！?？：～~]+$/, "")
@@ -307,7 +307,7 @@ for folder in folders do
                                         boxUp -= fontSize
                                     end
                                 end
-                                boxLeft += lineSpace
+                                boxLeft -= lineSpace
                             end
                         end
                     end


### PR DESCRIPTION
Two PDF readers I've tried (Firefox and koreader) both select text incorrectly if its rendered starting from left columns as Mokuro2Pdf previously did, starting from the left column. When copying these sentences to a dictionary, the result is a sentence with text transposed in chunks. This behavior is corrected if the PDF is rendered right to left.